### PR TITLE
bugfix/COD-16 | exclude sensitive properties from toString() method OpenAPI Generator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<liquibase.version>4.24.0</liquibase.version>
-		<openapi.version>7.0.1</openapi.version>
+		<openapi.version>7.1.0</openapi.version>
 		<swagger.version>2.2.16</swagger.version>
 		<org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
 		<jwt.version>0.12.3</jwt.version>

--- a/src/main/java/gmky/codebase/aop/LoggingAspect.java
+++ b/src/main/java/gmky/codebase/aop/LoggingAspect.java
@@ -1,7 +1,32 @@
 package gmky.codebase.aop;
 
 import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
 
 @Slf4j
+@Aspect
+@Component
 public class LoggingAspect {
+    @Pointcut("within(gmky.codebase.web.rest..*)")
+    public void restLoggingPointCut() {
+    }
+
+    @Around("restLoggingPointCut()")
+    public Object logging(ProceedingJoinPoint joinPoint) throws Throwable {
+        try {
+            log.info("Enter: {}() with argument[s] = {}", joinPoint.getSignature().getName(), Arrays.toString(joinPoint.getArgs()));
+            var result = joinPoint.proceed();
+            log.info("Exit: {}() with result = {}", joinPoint.getSignature().getName(), result);
+            return result;
+        } catch (IllegalArgumentException e) {
+            log.error("Illegal argument: {} in {}()", Arrays.toString(joinPoint.getArgs()), joinPoint.getSignature().getName());
+            throw e;
+        }
+    }
 }

--- a/src/main/java/gmky/codebase/model/entity/User.java
+++ b/src/main/java/gmky/codebase/model/entity/User.java
@@ -14,6 +14,7 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.time.Instant;
 import java.util.Set;
@@ -33,6 +34,7 @@ public class User extends AbstractAuditEntity {
     @Column(name = "EMAIL")
     private String email;
 
+    @ToString.Exclude
     @Column(name = "PASSWORD")
     private String password;
 

--- a/src/main/java/gmky/codebase/service/impl/AuthServiceImpl.java
+++ b/src/main/java/gmky/codebase/service/impl/AuthServiceImpl.java
@@ -29,7 +29,6 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public LoginResponse login(LoginReq req) {
-        log.info("Login with username: [{}]", req.getUsername());
         var user = userRepository.findByUsernameIgnoreCase(req.getUsername())
                 .orElseThrow(() -> new NotFoundException("Username not found"));
         var isMatched = passwordEncoder.matches(req.getPassword(), user.getPassword());

--- a/src/main/java/gmky/codebase/web/rest/v1/AuthResource.java
+++ b/src/main/java/gmky/codebase/web/rest/v1/AuthResource.java
@@ -24,7 +24,6 @@ public class AuthResource implements AuthenticationApi {
 
     @Override
     public ResponseEntity<LoginResponse> login(LoginReq loginReq) {
-        log.info("Login with username: [{}]", loginReq.getUsername());
         var result = authService.login(loginReq);
         return ResponseEntity.ok(result);
     }

--- a/src/main/resources/spec/client-api.yaml
+++ b/src/main/resources/spec/client-api.yaml
@@ -318,6 +318,7 @@ components:
           type: string
         password:
           type: string
+          format: password
         rememberMe:
           type: boolean
     LoginResponse:
@@ -325,8 +326,10 @@ components:
       properties:
         accessToken:
           type: string
+          format: password
         refreshToken:
           type: string
+          format: password
     CreateUserReq:
       type: object
       properties:


### PR DESCRIPTION
bugfix/COD-16 | exclude sensitive properties from toString() method OpenAPI Generator